### PR TITLE
fixReplicationManagerInit

### DIFF
--- a/src/FamixReplication/MooseModel.extension.st
+++ b/src/FamixReplication/MooseModel.extension.st
@@ -125,5 +125,5 @@ MooseModel >> replicationManager [
 
 { #category : #'*FamixReplication' }
 MooseModel >> replicationManager: anObject [
-	self privateState attributeAt: #replicationManager put: anObject
+	^ self privateState attributeAt: #replicationManager put: anObject
 ]


### PR DESCRIPTION
The value set here is used in initializeReplicationManager and then used in MooseModel>>#replicationManager (but the value is not returned.. so self is returned and a test fail)I believe this is the cause of the failling test in https://github.com/moosetechnology/Moose/pull/2277