### PR TITLE
Multiple optimization of FamixReplication

### DIFF
--- a/src/FamixReplication/FamixTSourceEntity.extension.st
+++ b/src/FamixReplication/FamixTSourceEntity.extension.st
@@ -1,14 +1,16 @@
 Extension { #name : 'FamixTSourceEntity' }
 
 { #category : '*FamixReplication' }
-FamixTSourceEntity >> addReplica: anObject [ 
-	self replicas add: anObject
+FamixTSourceEntity >> addReplica: anObject [
+	"If we do not have replicats but need to add one, we now save the collection in the cache in contrary of #replicas."
+
+	(self cacheAt: #replicas ifAbsentPut: [ OrderedCollection new ]) add: anObject
 ]
 
 { #category : '*FamixReplication' }
 FamixTSourceEntity >> clearReplicationCache [
 
-	self cacheAt: #replicas put: OrderedCollection new
+	self removeCache: #replicas
 ]
 
 { #category : '*FamixReplication' }
@@ -24,9 +26,14 @@ FamixTSourceEntity >> containsReplicas [
 	<FMProperty: #containsReplicas type: #Boolean>
 	<derived>
 	<FMComment: 'Flag true if the entity contains duplication.'>
-	self replicas ifNotEmpty: [ ^ true ].
+	
+	"If the cache is present, then there should be at least one replica"
+	self  cacheAt: #replicas ifPresent: [ ^ true ].
 
-	^ self containedEntities anySatisfy: #containsReplicas
+	"Iterating over the children for speed reason instead of using an #anySatisfy:"
+	self containedEntitiesDo: [ :child | child containsReplicas ifTrue: [  ^ true ] ].
+	
+	^ false
 ]
 
 { #category : '*FamixReplication' }
@@ -75,14 +82,16 @@ FamixTSourceEntity >> mergePossibleDuplications [
 
 { #category : '*FamixReplication' }
 FamixTSourceEntity >> removeReplica: aReplica [
-	self containsReplicas ifTrue: [ self replicas remove: aReplica ]
+
+	self cacheAt: #replicas ifPresent: [ :collection | collection remove: aReplica ]
 ]
 
 { #category : '*FamixReplication' }
 FamixTSourceEntity >> replicas [
+	"If the entity does not have replicats, return en empty collection that we will not save to not add overhead to the memory"
 
 	<FMProperty: #replicas type: #FamixReplica>
 	<FMComment: 'A collection of fragments of cloned code found in this program'>
 	<derived>
-	^ self cacheAt: #replicas ifAbsentPut: [ OrderedCollection new ]
+	^ self cacheAt: #replicas ifAbsent: [ OrderedCollection new ]
 ]

--- a/src/FamixReplication/MooseModel.extension.st
+++ b/src/FamixReplication/MooseModel.extension.st
@@ -6,9 +6,9 @@ MooseModel >> allBehaviouralsWithDuplicatedCode [
 	<navigation: 'All executables with duplicated code'>
 	^ self cacheAt: #allBehaviouralsWithDuplicatedCode ifAbsent: [
 			  'Compute allBehaviouralsWithDuplicatedCode' record. "Ensure the replication detection was run."
-			  self replicationManager ifNil: [ MooseUnavailableMetric ].
-
-			  self allModelBehaviourals select: #containsReplicas ]
+			  self replicationManager
+				  ifNotNil: [ self allModelBehaviourals select: #containsReplicas ]
+				  ifNil: [ MooseUnavailableMetric ] ]
 ]
 
 { #category : '*FamixReplication' }
@@ -17,9 +17,9 @@ MooseModel >> allContainersWithDuplicatedCode [
 	<navigation: 'All containers with duplicated code'>
 	^ self cacheAt: #allContainersWithDuplicatedCode ifAbsent: [
 			  'Compute allContainersWithDuplicatedCode' record. "Ensure the replication detection was run."
-			  self replicationManager ifNil: [ MooseUnavailableMetric ].
-
-			  self allModelContainers select: #containsReplicas ]
+			  self replicationManager
+				  ifNotNil: [ self allModelContainers select: #containsReplicas ]
+				  ifNil: [ MooseUnavailableMetric ] ]
 ]
 
 { #category : '*FamixReplication' }
@@ -84,14 +84,15 @@ MooseModel >> importReplicationFrom: file [
 
 { #category : '*FamixReplication' }
 MooseModel >> initializeReplicationManager [
-	self clearReplicationManager.
 
 	^ self replicationDetectionConfiguration
-		ifNil: [ 'No duplication configuration detected. Skip detection.' record.
-			nil ]
-		ifNotNil: [ :config | 
-			'Initialize replication detector' record.
-			(FamixRepDetector runOn: self entitiesForReplicationDetection with: config) in: [ :manager | self replicationManager: manager ] ]
+		  ifNil: [
+				  'No duplication configuration detected. Skip detection.' record.
+				  nil ]
+		  ifNotNil: [ :config |
+				  'Initialize replication detector' record.
+				  self clearReplicationManager.
+				  (FamixRepDetector runOn: self entitiesForReplicationDetection with: config) in: [ :manager | self replicationManager: manager ] ]
 ]
 
 { #category : '*FamixReplication' }


### PR DESCRIPTION
- Do not add an empty collection to the moose cache is there is no replica in an entity
- Some speed optimizations
- Fix a bug in #removeReplica: because it was using a method that considered the children and not only the entity
- Fix #allBehaviouralsWithDuplicatedCode and #allContainersWithDuplicatedCode that were doing useless computation when there are no replication manager declared for a language
- Speedup #initializeReplicationManager when there is not replication manager (no need to reset the caches)